### PR TITLE
Add new option to set overflow property

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,7 @@ ps-custom-top (optional) = custom CSS for panel top (only applicable in 'right',
 ps-custom-bottom (optional) = custom CSS for panel bottom (only applicable in 'right', 'left' or 'bottom' panels)
 ps-custom-left (optional) = custom CSS for panel left (only applicable in 'left', 'top' or 'bottom' panels)
 ps-custom-right (optional) = custom CSS for panel right (only applicable in 'right', 'top' or 'bottom' panels)
+ps-overflow (optional) = Set the value of the CSS overflow property
 ```
 
 ## Licensing

--- a/src/angular-pageslide-directive.js
+++ b/src/angular-pageslide-directive.js
@@ -22,6 +22,7 @@ pageslideDirective.directive('pageslide', [
                 param.side = attrs.pageslide || 'right';
                 param.speed = attrs.psSpeed || '0.5';
                 param.size = attrs.psSize || '300px';
+                param.overflow = attrs.psOverflow || '';
 
                 /* DOM manipulation */
                 //console.log(el);
@@ -41,6 +42,7 @@ pageslideDirective.directive('pageslide', [
                 /* Style setup */
                 slider.style.transitionDuration = param.speed + 's';
                 slider.style.webkitTransitionDuration = param.speed + 's';
+                slider.style.overflow = param.overflow;
                 slider.style.zIndex = 1000;
                 slider.style.position = 'fixed';
                 slider.style.width = 0;


### PR DESCRIPTION
Allow the user to set an overflow attribute. Useful if the panel contains more information than can fit on the screen.
