### PR TITLE
bower version bump and main file path fix. Also referencing non minified...

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "angular-pageslide-directive",
-    "version": "0.1.6",
-    "main": "build/angular-pageslide-directive.min.js",
+    "version": "0.1.7",
+    "main": "dist/angular-pageslide-directive.js",
     "authors": [
         "Daniele Piccone <mail@danielepiccone.com> (http://www.danielepiccone.com)",
         "Tim Borny <bornytm@gmail.com>"
@@ -20,5 +20,3 @@
         "grunt-contrib-uglify": "~0.2.2"
     }
 }
-
-


### PR DESCRIPTION
Changed the bower main file path to reflect actual dir structure. Also did a version bump and tagged 0.1.7 and v0.1.7.

This is a fix for [#15](https://github.com/dpiccone/ng-pageslide/issues/15)
