### PR TITLE
start with slider closed if required, to avoid on load slide

### DIFF
--- a/src/angular-pageslide-directive.js
+++ b/src/angular-pageslide-directive.js
@@ -147,6 +147,9 @@
                     slider.addEventListener('transitionend', onTransitionEnd);
 
                     initSlider();
+                    //if the slide is supposed to be closed, ensure its closed so we can avoid onload close
+                    if (angular.isDefined(scope.psOpen) && scope.psOpen === false)
+                        psClose(slider, param);
 
                     function initSlider() {
                         switch (param.side) {


### PR DESCRIPTION
The slider was appearing and disappearing on load if psOpen is marked as false on load.